### PR TITLE
JBPM-6230 Additional fix for concurrent request failures.

### DIFF
--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/balancer/LoadBalancer.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/balancer/LoadBalancer.java
@@ -62,8 +62,7 @@ public class LoadBalancer {
         
         String baseUrl = balancerStrategy.markAsOffline(url);
         failedEndpoints.add(baseUrl);
-        logger.debug("Url '{}' is marked as failed and will be considered offline by {}", url, balancerStrategy);
-        
+        logger.debug("failed endpoint '{}' from Url '{}' is marked as failed and will be considered offline by {}  - failedEndpoints size='{}'", baseUrl, url, balancerStrategy, failedEndpoints.size());
         return baseUrl;
     }
 
@@ -71,7 +70,7 @@ public class LoadBalancer {
         
         String baseUrl = balancerStrategy.markAsOnline(url);
         failedEndpoints.remove(baseUrl);
-        logger.debug("Url '{}' is marked as activated and will be considered online by {}", url, balancerStrategy);
+        logger.debug("failed endpoint '{}' from Url '{}' is marked as activated and will be considered online by {} - failedEndpoints size='{}'", baseUrl, url, balancerStrategy, failedEndpoints.size());
     }
 
     public void close() {

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/AbstractKieServicesClientImpl.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/AbstractKieServicesClientImpl.java
@@ -53,6 +53,8 @@ import org.kie.server.client.jms.ResponseHandler;
 import org.kie.server.common.rest.KieServerHttpRequest;
 import org.kie.server.common.rest.KieServerHttpRequestException;
 import org.kie.server.common.rest.KieServerHttpResponse;
+import org.kie.server.common.rest.NoEndpointFoundException;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -805,7 +807,18 @@ public abstract class AbstractKieServicesClientImpl {
             } catch (KieServerHttpRequestException e) {
                 if (e.getCause() instanceof IOException) {
                     logger.debug("Marking endpoint '{}' as failed due to {}", url, e.getCause().getMessage());
-                    String failedBaseUrl = loadBalancer.markAsFailed(url);
+                    String failedBaseUrl = null;
+                    // Need to block when concurrent failures attempt update of availableEndpoints.
+                    // Once availableEndpoints is drained, all remaining failures result in 
+                    // NoEndpointFoundException.
+                    synchronized(this) {
+                    	if (!loadBalancer.getAvailableEndpoints().isEmpty()) {
+                    		failedBaseUrl = loadBalancer.markAsFailed(url);
+                    	}
+                    	else {
+                    		throw new NoEndpointFoundException("No endpoints");
+                    	}
+                    }
                     nextUrl = loadBalancer.getUrl();
                     url = url.replace(failedBaseUrl, nextUrl);
                     logger.debug("Selecting next endpoint from load balancer - '{}'", url);

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/test/java/org/kie/server/client/LoadBalancerClientTest.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/test/java/org/kie/server/client/LoadBalancerClientTest.java
@@ -18,15 +18,18 @@ package org.kie.server.client;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.stubbing.Scenario;
 import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.kie.server.common.rest.KieServerHttpRequestException;
+import org.kie.server.common.rest.NoEndpointFoundException;
 import org.kie.server.api.model.KieServerInfo;
 import org.kie.server.api.model.KieServerStateInfo;
 import org.kie.server.api.model.ServiceResponse;
@@ -301,6 +304,233 @@ public class LoadBalancerClientTest {
         Assertions.assertThat(response.getResult().getContainers()).isEmpty();
     }
 
+   
+    @Test
+    public void testMultipleConcurrentFailRequestsForLoadBalancerWithSingleServer() throws Exception {
+
+    	class SendKieRequestThread extends Thread {
+            CountDownLatch startLatch;
+            CountDownLatch stopLatch;
+            int threadNo;
+            KieServicesClient kieClient;
+
+            SendKieRequestThread(int threadNo, CountDownLatch startLatch, CountDownLatch stopLatch, KieServicesClient client) {
+                this.startLatch = startLatch;
+                this.stopLatch = stopLatch;
+                this.threadNo = threadNo; 
+                this.kieClient = client;
+            }
+
+            @Override
+            public void run() {
+                try {
+                    startLatch.await();
+                    System.out.println("Th#" + threadNo + " Calling Kie Server "); 
+                    
+                    // Stagger execution of threads by 20ms
+                    Thread.sleep(20 * threadNo);
+                    // Call KieServer... 
+                    try {
+                    	ServiceResponse<KieServerStateInfo> response = this.kieClient.getServerState();
+                        fail("Unexpected successful request");
+                    } catch (NoEndpointFoundException e) {
+                        // expected failed configured in "Timeout Fail followed by Success" scenario 
+                    }
+                    
+                } catch (Exception e) {
+                    e.printStackTrace();
+                } finally {
+                    System.out.println("Th#" + threadNo +" Done.");
+                    stopLatch.countDown();
+                }
+            }
+        }
+   	
+    	// Setup a single server
+        config = KieServicesFactory.newRestConfiguration( mockServerBaseUri1, null, null );
+        config.setCapabilities(Arrays.asList("KieServer"));
+
+        KieServicesClient client = KieServicesFactory.newKieServicesClient(config);
+        
+        // Issue successful request 
+        ServiceResponse<KieServerStateInfo> response = client.getServerState();
+        assertSuccess(response);
+        Assertions.assertThat(response.getResult().getContainers()).isEmpty();
+
+        // Setup 2 concurrent requests both failing with a timeout representing a temporary failure in server
+        wireMockServer1.stubFor(get(urlEqualTo("/state"))
+                .withHeader("Accept", equalTo("application/xml"))
+                .inScenario("Timeout Fails followed by Scan Success")
+                .whenScenarioStateIs(Scenario.STARTED) 
+                .willReturn(aResponse()
+                		.withFixedDelay(5100)
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/xml")
+                        .withBody("<response type=\"SUCCESS\" msg=\"Kie Server state\">\n" +
+                                "  <kie-server-state-info>\n" +
+                                "    <version>1a</version>\n" +
+                                "  </kie-server-state-info>\n" +
+                                "</response>"))
+                .willSetStateTo("Req Timeout 1")); 
+
+        wireMockServer1.stubFor(get(urlEqualTo("/state"))
+                .withHeader("Accept", equalTo("application/xml"))
+                .inScenario("Timeout Fails followed by Scan Success")
+                .whenScenarioStateIs("Req Timeout 1") 
+                .willReturn(aResponse()
+                		.withFixedDelay(5100)
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/xml")
+                        .withBody("<response type=\"SUCCESS\" msg=\"Kie Server state\">\n" +
+                                "  <kie-server-state-info>\n" +
+                                "    <version>1b</version>\n" +
+                                "  </kie-server-state-info>\n" +
+                                "</response>"))
+                .willSetStateTo("Req Timeout 2")); 
+
+        // Add a delay to background thread scanning to ensure availableEndpoints list 
+        // is kept empty long enough to demonstrate failing situation.
+        wireMockServer1.stubFor(get(urlEqualTo("/"))
+                .inScenario("Timeout Fails followed by Scan Success")
+                .whenScenarioStateIs("Req Timeout 2") 
+                .willReturn(aResponse()
+                		.withFixedDelay(500)
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/xml")
+                        .withBody("<response type=\"SUCCESS\" msg=\"Kie Server info\">\n" +
+                                "  <kie-server-info>\n" +
+                                "    <version>background scan</version>\n" +
+                                "  </kie-server-info>\n" +
+                                "</response>"))
+                .willSetStateTo("Good Req 1")); 
+        
+        // Request to indicate server is back online
+        wireMockServer1.stubFor(get(urlEqualTo("/state"))
+                .withHeader("Accept", equalTo("application/xml"))
+                .inScenario("Timeout Fails followed by Scan Success")
+                .whenScenarioStateIs("Good Req 1") 
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/xml")
+                        .withBody("<response type=\"SUCCESS\" msg=\"Kie Server state\">\n" +
+                                "  <kie-server-state-info>\n" +
+                                "    <version>1c</version>\n" +
+                                "  </kie-server-state-info>\n" +
+                                "</response>"))
+                .willSetStateTo("Good Req 2")); 
+        
+        // Kickoff first scenario 
+        int threadCount=2;
+        System.out.println("Starting 2 Threads");
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch stopLatch = new CountDownLatch(threadCount); 
+        for (int i=1; i<= threadCount; i++) {
+            new SendKieRequestThread(i, startLatch, stopLatch, client).start();
+        }
+        // Threads will be waiting to proceed, so let them off.
+        startLatch.countDown();
+
+        // We expect the threads to complete within 7 seconds
+        stopLatch.await(7, TimeUnit.SECONDS);
+        System.out.println("\nEnd of Threads - ");
+
+        // Need to sleep to ensure background thread completes.
+        System.out.println("\nSleeping for 3 seconds - ");
+        Thread.sleep(3000);
+
+        // Expect to now have server:/state incorrectly retained in failedEndpoints
+        List<String> availableList = ((AbstractKieServicesClientImpl)client).getLoadBalancer().getAvailableEndpoints();
+        availableList.forEach(item -> System.out.println("Available Endpoint : [" + item + "]")); 
+        List<String> failedList = ((AbstractKieServicesClientImpl)client).getLoadBalancer().getFailedEndpoints();
+        failedList.forEach(item -> System.out.println("Failed Endpoint : [" + item + "]"));
+        
+        // Now set up a subsequent request failure due to server temporarily not responding.");
+        // Could have many successful requests up to this point after first failing scenario but as 
+        // soon as we have another timeout failure like below, server:/state gets moved to availableEndpoints.
+        wireMockServer1.stubFor(get(urlEqualTo("/state"))
+        		.withHeader("Accept", equalTo("application/xml"))
+        		.inScenario("Brief Timeout Fails followed by Scan Success")
+        		.willReturn(aResponse()
+        				.withFixedDelay(5100)
+        				.withStatus(200)
+        				.withHeader("Content-Type", "application/xml")
+        				.withBody("<response type=\"SUCCESS\" msg=\"Kie Server state\">\n" +
+        						"  <kie-server-state-info>\n" +
+        						"    <version>1d</version>\n" +
+        						"  </kie-server-state-info>\n" +
+        						"</response>"))
+        		.willSetStateTo("After Failed Req"));
+        
+        wireMockServer1.stubFor(get(urlEqualTo("/state"))
+        		.inScenario("Brief Timeout Fails followed by Scan Success")
+                .whenScenarioStateIs("After Failed Req") 
+        		.willReturn(aResponse()
+        				.withStatus(200)
+        				.withHeader("Content-Type", "application/xml")
+        				.withBody("<response type=\"SUCCESS\" msg=\"Kie Server state\">\n" +
+        						"  <kie-server-state-info>\n" +
+        						"    <version>1e</version>\n" +
+        						"  </kie-server-state-info>\n" +
+        						"</response>"))
+        		.willSetStateTo("After success 1"));
+        
+        wireMockServer1.stubFor(get(urlEqualTo("/"))
+              .inScenario("Brief Timeout Fails followed by Scan Success")
+              .whenScenarioStateIs("After success 1") 
+              .willReturn(aResponse()
+                      .withStatus(200)
+                      .withHeader("Content-Type", "application/xml")
+                      .withBody("<response type=\"SUCCESS\" msg=\"Kie Server info\">\n" +
+                              "  <kie-server-info>\n" +
+                              "    <version>background scan</version>\n" +
+                              "  </kie-server-info>\n" +
+      						"</response>"))
+      		.willSetStateTo("After success 2"));
+        System.out.println(" Current wireMockServer1 stub count =" + wireMockServer1.listAllStubMappings().getMappings().size());
+
+        // Make call to failing request
+        try {
+        	response = client.getServerState();
+        	fail("Unexpected successful request");
+        } catch (NoEndpointFoundException e) {
+        	// expect failure
+        }
+
+        // Expect to now have server:/state incorrectly retained in availableEndpoints transferred from failedEndpoints
+        availableList = ((AbstractKieServicesClientImpl)client).getLoadBalancer().getAvailableEndpoints();
+        availableList.forEach(item -> System.out.println("Available Endpoint : [" + item + "]")); 
+        failedList = ((AbstractKieServicesClientImpl)client).getLoadBalancer().getFailedEndpoints();
+        if (failedList.isEmpty()) {
+        	System.out.println("Failed Endpoint : []");
+        }
+        else {
+        	failedList.forEach(item -> System.out.println("Failed Endpoint : [" + item + "]"));
+        }
+
+        // Need delay here to give background thread a chance to complete scanning to see if server is online
+        Thread.sleep(1000);
+        
+        // Set up what should be a successful request
+        wireMockServer1.stubFor(get(urlEqualTo("/state"))
+                .withHeader("Accept", equalTo("application/xml"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/xml")
+                        .withBody("<response type=\"SUCCESS\" msg=\"Kie Server state\">\n" +
+                                "  <kie-server-state-info>\n" +
+                                "    <version>1b</version>\n" +
+                                "  </kie-server-state-info>\n" +
+                                "</response>")));
+
+        // Run request and expect success request but instead a 404 HTTP status results
+        // due to final request URL generated as "http://localhost:<port>/state/state"
+        // based on presence of server:/state in availableEndpoints.
+        response = client.getServerState();
+        assertSuccess(response);
+        Assertions.assertThat(response.getResult().getContainers()).isEmpty();
+    }
+    
+    
     private void assertSuccess(ServiceResponse<?> response) {
         assertEquals("Response type", ServiceResponse.ResponseType.SUCCESS, response.getType());
     }


### PR DESCRIPTION
Added test to demonstrate sequence of events eventually leading to invalid URL construction and 404 HTTP status errors.
Applied fix to prevent failure by preventing addition of a failing URL to failedEndpoints in LoadBalancer.

Enable debugging of test in kie-server-client/src/test/resources/logback-test.xml to evaluate runtime for test testMultipleConcurrentFailRequestsForLoadBalancerWithSingleServer.